### PR TITLE
expose madx errors

### DIFF
--- a/src/cpymad/clibmadx.pxd
+++ b/src/cpymad/clibmadx.pxd
@@ -169,6 +169,9 @@ cdef extern from "madX/mad_node.h" nogil:
         expression* at_expr
         char* from_name
         element* p_elem
+        double_array* p_al_err
+        double_array* p_fd_err
+        double_array* p_ph_err
 
     struct node_list:
         int curr

--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -1127,7 +1127,7 @@ cdef bytes _cstr(s):
 cdef _node_name(clib.node* node):
     return name_from_internal(_str(node.name))
 
-cdef _double_array(clib.double_array* ptr):
+cdef _double_array_copy(clib.double_array* ptr):
     arr = np.empty(ptr.curr,dtype='d')
     for ii in range(ptr.curr):
         arr[ii]=ptr.a[ii]
@@ -1155,11 +1155,11 @@ cdef _get_node(clib.node* node, int ref_flag, int is_expanded, int line):
     data['position'] = _get_node_entry_pos(node, ref_flag, is_expanded)
     data['length'] = node.length
     if node.p_al_err is not NULL:
-        data['align_errors']=_double_array(node.p_al_err)
+        data['align_errors']=_double_array_copy(node.p_al_err)
     if node.p_fd_err is not NULL:
-        data['field_errors']=_double_array(node.p_fd_err)
+        data['field_errors']=_double_array_copy(node.p_fd_err)
     if node.p_ph_err is not NULL:
-        data['phase_errors']=_double_array(node.p_ph_err)
+        data['phase_errors']=_double_array_copy(node.p_ph_err)
     return data
 
 

--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -1127,6 +1127,12 @@ cdef bytes _cstr(s):
 cdef _node_name(clib.node* node):
     return name_from_internal(_str(node.name))
 
+cdef _double_array(clib.double_array* ptr):
+    addr = <Py_intptr_t> ptr.a
+    array_type = ctypes.c_double * ptr.curr
+    array_data = array_type.from_address(addr)
+    return np.ctypeslib.as_array(array_data)
+
 
 cdef _get_node(clib.node* node, int ref_flag, int is_expanded, int line):
     """Return dictionary with node + element attributes."""
@@ -1149,6 +1155,12 @@ cdef _get_node(clib.node* node, int ref_flag, int is_expanded, int line):
     data['base_name'] = _str(node.base_name)
     data['position'] = _get_node_entry_pos(node, ref_flag, is_expanded)
     data['length'] = node.length
+    if node.p_al_err is not NULL:
+        data['align_errors']=_double_array(node.p_al_err)
+    if node.p_fd_err is not NULL:
+        data['field_errors']=_double_array(node.p_fd_err)
+    if node.p_ph_err is not NULL:
+        data['phase_errors']=_double_array(node.p_ph_err)
     return data
 
 

--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -1128,11 +1128,10 @@ cdef _node_name(clib.node* node):
     return name_from_internal(_str(node.name))
 
 cdef _double_array(clib.double_array* ptr):
-    addr = <Py_intptr_t> ptr.a
-    array_type = ctypes.c_double * ptr.curr
-    array_data = array_type.from_address(addr)
-    return np.ctypeslib.as_array(array_data)
-
+    arr = np.empty(ptr.curr,dtype='d')
+    for ii in range(ptr.curr):
+        arr[ii]=ptr.a[ii]
+    return arr
 
 cdef _get_node(clib.node* node, int ref_flag, int is_expanded, int line):
     """Return dictionary with node + element attributes."""


### PR DESCRIPTION
I implemented a basic support for extracting field errors from the sequence. See this example:

```
from cpymad.madx import Madx
from cpymad import libmadx

mad=Madx()
mad.call("fodo.madx")
qf=mad.sequence['fodo'].expanded_elements['qf']
field_err1=qf._attr['field_errors']

libmadx.start()
libmadx.input('call,file="fodo.madx";')
qf=libmadx.get_expanded_element("fodo",2)
field_err2=qf['field_errors']

print(field_err1)
print(field_err2)
```

where `fodo.madx` contains
```
beam,particle=proton,gamma=1.1;
mq: multipole;
qf: mq,knl:={0,kqf};
qd: mq,knl:={0,kqd};
dr: drift,l:=ld;

kqf=0.8;
kqd=-0.7;
ld=1.2;

fodo : line = (dr,qf,dr,qd);
use,period=fodo;

select, flag=error, range=qf;
efcomp, dkn={ 1e-6, 2e-6,3e-6},
        dks={-1e-6,-2e-6,-3e-6};

twiss;
eprint;
```