### PR TITLE
add test mad errors

### DIFF
--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -33,6 +33,21 @@ from cpymad.util import name_to_internal, name_from_internal, normalize_range_na
 cimport cpymad.clibmadx as clib
 
 
+cdef class FieldError:
+    cdef public object dkn
+    cdef public object dks
+
+cdef class AlignError:
+    cdef public double dx
+    cdef public double dy
+    ...
+
+cdef class PhaseError:
+    cdef public object dpn
+    cdef public object dps
+
+
+
 # Remember whether start() was called
 _madx_started = False
 

--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -33,21 +33,6 @@ from cpymad.util import name_to_internal, name_from_internal, normalize_range_na
 cimport cpymad.clibmadx as clib
 
 
-cdef class FieldError:
-    cdef public object dkn
-    cdef public object dks
-
-cdef class AlignError:
-    cdef public double dx
-    cdef public double dy
-    ...
-
-cdef class PhaseError:
-    cdef public object dpn
-    cdef public object dps
-
-
-
 # Remember whether start() was called
 _madx_started = False
 

--- a/test/test_madx.py
+++ b/test/test_madx.py
@@ -102,14 +102,10 @@ class TestMadx(unittest.TestCase, _TestCaseCompat):
         output = []
         m = Madx(stdout=output.append)
         self.assertEqual(len(output), 1)
-        self.assertIn(
-            b'++++++++++++++++++++++++++++++++++++++++++++', output[0])
-        self.assertIn(b'+ Support: mad@cern.ch,',
-                      output[0])
-        self.assertIn(b'+ Release   date: ',
-                      output[0])
-        self.assertIn(b'+ Execution date: ',
-                      output[0])
+        self.assertIn(b'++++++++++++++++++++++++++++++++++++++++++++', output[0])
+        self.assertIn(b'+ Support: mad@cern.ch,',                      output[0])
+        self.assertIn(b'+ Release   date: ',                           output[0])
+        self.assertIn(b'+ Execution date: ',                           output[0])
         # self.assertIn(b'+ Support: mad@cern.ch, ', output[1])
         m.input('foo = 3;')
         self.assertEqual(len(output), 1)
@@ -727,12 +723,16 @@ class TestMadx(unittest.TestCase, _TestCaseCompat):
         mad.beam()
         mad.use(sequence='s1')
         mad.select(flag='error', range='qp')
-        mad.efcomp(dkn=[1e-6, 2e-6, 3e-6], dks=[-1e-6, -2e-6, -3e-6])
+        dkn=[1e-6, 2e-6, 3e-6]
+        dks=[4e-6, 5e-6, 6e-6]
+        mad.efcomp(dkn=dkn, dks=dks)
         mad.ealign(dx=1e-3,dy=-4e-3)
-        assert mad.sequence['s1'].expanded_elements['qp'].field_errors[0]==1e-6
-        assert mad.sequence['s1'].expanded_elements['qp'].field_errors[3]==-2e-6
-        assert mad.sequence['s1'].expanded_elements['qp'].align_errors[0]==1e-3
-        assert mad.sequence['s1'].expanded_elements['qp'].align_errors[1]==-4e-3
+        fd =mad.sequence['s1'].expanded_elements['qp'].field_errors
+        al =mad.sequence['s1'].expanded_elements['qp'].align_errors
+        assert_allclose(fd[:6:2],dkn)
+        assert_allclose(fd[1:6:2],dks)
+        assert_allclose(al[0],1e-3)
+        assert_allclose(al[1],-4e-3)
 
 
 class TestTransferMap(unittest.TestCase):

--- a/test/test_madx.py
+++ b/test/test_madx.py
@@ -102,10 +102,14 @@ class TestMadx(unittest.TestCase, _TestCaseCompat):
         output = []
         m = Madx(stdout=output.append)
         self.assertEqual(len(output), 1)
-        self.assertIn(b'++++++++++++++++++++++++++++++++++++++++++++', output[0])
-        self.assertIn(b'+ Support: mad@cern.ch,',                      output[0])
-        self.assertIn(b'+ Release   date: ',                           output[0])
-        self.assertIn(b'+ Execution date: ',                           output[0])
+        self.assertIn(
+            b'++++++++++++++++++++++++++++++++++++++++++++', output[0])
+        self.assertIn(b'+ Support: mad@cern.ch,',
+                      output[0])
+        self.assertIn(b'+ Release   date: ',
+                      output[0])
+        self.assertIn(b'+ Execution date: ',
+                      output[0])
         # self.assertIn(b'+ Support: mad@cern.ch, ', output[1])
         m.input('foo = 3;')
         self.assertEqual(len(output), 1)
@@ -717,6 +721,18 @@ class TestMadx(unittest.TestCase, _TestCaseCompat):
             }
         ''')
         self.assertEqual(var.x, 3)
+
+    def test_field_errors(self):
+        mad = self.mad
+        mad.beam()
+        mad.use(sequence='s1')
+        mad.select(flag='error', range='qp')
+        mad.efcomp(dkn=[1e-6, 2e-6, 3e-6], dks=[-1e-6, -2e-6, -3e-6])
+        mad.ealign(dx=1e-3,dy=-4e-3)
+        assert mad.sequence['s1'].expanded_elements['qp'].field_errors[0]==1e-6
+        assert mad.sequence['s1'].expanded_elements['qp'].field_errors[3]==-2e-6
+        assert mad.sequence['s1'].expanded_elements['qp'].align_errors[0]==1e-3
+        assert mad.sequence['s1'].expanded_elements['qp'].align_errors[1]==-4e-3
 
 
 class TestTransferMap(unittest.TestCase):


### PR DESCRIPTION
I added a simple test for field errors.

The user interface is at the moment a bit difficult because the user has to know how the data is arranged in the arrays.

What do you think returning `namedtuples` or dict instead of bare arrays like:
FieldError(dkn=, dks=)
AlignError(dx=, dy= ....)
 
such that they could be even feed back in `efcomp` or `align`?
 