### PR TITLE
combining stderr to stdout in subprocess pipe to get the last line of…

### DIFF
--- a/src/cpymad/madx.py
+++ b/src/cpymad/madx.py
@@ -159,6 +159,7 @@ class Madx(object):
                     stdout = stdout.write
             Popen_args['stdout'] = \
                 subprocess.PIPE if callable(stdout) else stdout
+            Popen_args['stderr'] =  Popen_args['stdout']
             # stdin=None leads to an error on windows when STDIN is broken.
             # Therefore, we need set stdin=os.devnull by passing stdin=False:
             Popen_args.setdefault('stdin', False)


### PR DESCRIPTION
This PR allows to see the crash message of MAD-X into the pipe by combining *stderr* to the set *stdout*.

```python
from cpymad.madx import Madx


with open('madx_output.log', 'w') as f:
    madx = Madx(stdout=f)

try :
    madx.input('tl.common: at=100')
except:
    pass


with open('madx_output.log', 'r') as f:
    lines = f.readlines()
    
lines
```

MAD-X crashes on the raw input. With this commit the last element of *lines* is the MAD-X error `+=+=+= fatal: unknown class type: at` while it is missing without.

That is not so relevant as the error appears in the terminal by default but with jupyter we so not always have access to the terminal running the kernel.