### PR TITLE
Update to 5.06.01

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  MADX_VERSION: 5.06.00
+  MADX_VERSION: 5.06.01
 
 jobs:
   build_linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install cpymad from wheel
         run: |
           set -ex
-          pip install -U pip
+          python -m pip install -U pip || sudo python -m pip install -U pip
           pip install cpymad -f dist --no-index --no-deps
           pip install cpymad
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 ~~~~~~~~~
 
+1.6.0
+=====
+Date: 04.09.2020
+
+- update to MAD-X 5.06.01
+- halfen linux wheels sizes by building with -fvisibility=hidden and -flto,
+  hopefully increasing performance
+- internal improvements with the CI setup:
+- CI tests more configurations than before
+- CI tests should now run on pull-requests
+- reduce complexity
+
+
 1.5.0
 =====
 Date: 27.08.2020

--- a/doc/installation/unix.rst
+++ b/doc/installation/unix.rst
@@ -34,8 +34,8 @@ programs:
 
 Download the `latest MAD-X release`_ `from github`_::
 
-    wget https://github.com/MethodicalAcceleratorDesign/MAD-X/archive/5.06.00.tar.gz
-    tar -xzf MAD-X-5.06.00.tar.gz
+    wget https://github.com/MethodicalAcceleratorDesign/MAD-X/archive/5.06.01.tar.gz
+    tar -xzf MAD-X-5.06.01.tar.gz
 
 or use directly the source code from master (unstable)::
 

--- a/src/cpymad/__init__.py
+++ b/src/cpymad/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 __title__ = 'cpymad'
-__version__ = '1.5.0'
+__version__ = '1.6.0'
 
 __summary__ = 'Cython binding to MAD-X'
 __uri__ = 'https://github.com/hibtc/cpymad'


### PR DESCRIPTION
@tpersson Could you push the `5.06.01` tag for the new MAD-X release to github so cpymad can fetch the version?