### PR TITLE
Build and test wheels for macos

### DIFF
--- a/.github/build/macos/cpymad.sh
+++ b/.github/build/macos/cpymad.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+export CC=gcc-9
+export MADXDIR=../MAD-X/dist
+export BLAS=1 LAPACK=1
+pip install cython wheel
+python setup.py sdist bdist_wheel

--- a/.github/build/macos/cpymad.sh
+++ b/.github/build/macos/cpymad.sh
@@ -1,6 +1,30 @@
 #! /usr/bin/env bash
+set -ex
 export CC=gcc-9
 export MADXDIR=../MAD-X/dist
 export BLAS=1 LAPACK=1
-pip install cython wheel
-python setup.py sdist bdist_wheel
+
+build()
+{
+    py_ver=$1
+
+    conda_ create -qyf -n py$py_ver python=$py_ver wheel cython -c anaconda
+    conda_ activate py$py_ver
+    pip install -U setuptools
+    rm -f src/cpymad/libmadx.c
+    python setup.py sdist bdist_wheel
+    conda_ deactivate
+}
+
+conda_() {
+    # Conda with disabled trace (really noisy otherwise):
+    { set +x; } 2>/dev/null
+    conda "$@"
+    { set -x; } 2>/dev/null
+}
+
+build 2.7
+build 3.5
+build 3.6
+build 3.7
+build 3.8

--- a/.github/build/macos/cpymad.sh
+++ b/.github/build/macos/cpymad.sh
@@ -3,4 +3,4 @@ export CC=gcc-9
 export MADXDIR=../MAD-X/dist
 export BLAS=1 LAPACK=1
 pip install cython wheel
-python setup.py sdist bdist_wheel -p macosx_10_9_x86_64
+python setup.py sdist bdist_wheel

--- a/.github/build/macos/cpymad.sh
+++ b/.github/build/macos/cpymad.sh
@@ -3,4 +3,4 @@ export CC=gcc-9
 export MADXDIR=../MAD-X/dist
 export BLAS=1 LAPACK=1
 pip install cython wheel
-python setup.py sdist bdist_wheel
+python setup.py sdist bdist_wheel -p macosx_10_9_x86_64

--- a/.github/build/macos/madx.sh
+++ b/.github/build/macos/madx.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+set -ex
+
+# Build MAD-X static library from prepared sources.
+# Must be run from the root the directory of the MAD-X sources.
+# Builds in './build' and installs to './dist'.
+
+rm -rf build
+mkdir build
+cd build
+
+pip3 install --upgrade cmake
+cmake .. \
+    -DCMAKE_POLICY_DEFAULT_CMP0077=NEW \
+    -DCMAKE_POLICY_DEFAULT_CMP0042=NEW \
+    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+    -DCMAKE_C_COMPILER=gcc-9 \
+    -DCMAKE_CXX_COMPILER=g++-9 \
+    -DCMAKE_Fortran_COMPILER=gfortran-9 \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DMADX_STATIC=OFF \
+    -DCMAKE_INSTALL_PREFIX=../dist \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DMADX_INSTALL_DOC=OFF \
+    -DMADX_ONLINE=OFF \
+    -DMADX_FORCE_32=OFF \
+    -DMADX_X11=OFF
+cmake --build . --target install

--- a/.github/checkout-madx/action.yml
+++ b/.github/checkout-madx/action.yml
@@ -12,3 +12,6 @@ runs:
       shell: bash
     - run: patch -d ../MAD-X -p1 < .github/patch/fix-cmake-Fortran_FLAGS.patch
       shell: bash
+    - name: 'Fix runtime error on macos: "Symbol not found: _mad_argc"'
+      run: patch -d ../MAD-X -p1 < .github/patch/fix-macos-symbol-not-found-mad_argc.patch
+      shell: bash

--- a/.github/patch/fix-macos-symbol-not-found-mad_argc.patch
+++ b/.github/patch/fix-macos-symbol-not-found-mad_argc.patch
@@ -1,0 +1,16 @@
+--- a/src/mad_main.c
++++ b/src/mad_main.c
+@@ -7,9 +7,10 @@
+ #undef  const
+ 
+ // readonly global information about program's command line arguments and stack base
+-int     mad_argc;
+-char**  mad_argv;
+-void*   mad_stck;
++#include <stddef.h>
++int     mad_argc = 0;
++char**  mad_argv = NULL;
++void*   mad_stck = NULL;
+ 
+ #ifdef _GFORTRAN
+ #define _POSIX_C_SOURCE 200112L

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,8 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.9"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,15 +118,87 @@ jobs:
           name: dist-windows-${{ matrix.arch }}
           path: dist
 
+  build_macos:
+    name: "Build: MacOS"
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x86_64]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download cached MAD-X build
+        id: madx-build-cache
+        # Do NOT use cache@v2, it can't handle relative paths with '..' nor
+        # absolute paths on windows!
+        uses: actions/cache@v1
+        with:
+          path: ../MAD-X/dist
+          key: "\
+            madx-${{ env.MADX_VERSION }}-\
+            macos-${{ matrix.arch }}-\
+            patches-${{ hashFiles('.github/patch/*') }}-\
+            scripts-${{ hashFiles('.github/build/macos/madx*') }}\
+          "
+
+      - name: Prepare MAD-X source
+        if: steps.madx-build-cache.outputs.cache-hit != 'true'
+        uses: ./.github/checkout-madx
+        with:
+          madx_version: ${{ env.MADX_VERSION }}
+
+      - name: Build MAD-X
+        if: steps.madx-build-cache.outputs.cache-hit != 'true'
+        run: |
+          cd ../MAD-X
+          ../cpymad/.github/build/macos/madx.sh
+
+      - name: Setup python 2.7
+        uses: actions/setup-python@v2
+        with: {python-version: '2.7'}
+      - run: .github/build/macos/cpymad.sh
+
+      - name: Setup python 3.5
+        uses: actions/setup-python@v2
+        with: {python-version: '3.5'}
+      - run: .github/build/macos/cpymad.sh
+
+      - name: Setup python 3.6
+        uses: actions/setup-python@v2
+        with: {python-version: '3.6'}
+      - run: .github/build/macos/cpymad.sh
+
+      - name: Setup python 3.7
+        uses: actions/setup-python@v2
+        with: {python-version: '3.7'}
+      - run: .github/build/macos/cpymad.sh
+
+      - name: Setup python 3.8
+        uses: actions/setup-python@v2
+        with: {python-version: '3.8'}
+      - run: .github/build/macos/cpymad.sh
+
+      - name: Fixup wheel dependencies
+        run: |
+          pip3 install delocate
+          delocate-wheel dist/*.whl
+          delocate-listdeps --all dist/*.whl
+
+      - name: Upload cpymad wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-macos-${{ matrix.arch }}
+          path: dist
+
   test:
     name: Tests
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu' || 'windows' }}-latest
-    needs: [build_linux, build_windows]
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu' || matrix.os }}-latest
+    needs: [build_linux, build_windows, build_macos]
     strategy:
       matrix:
         # 32bit python is currently only available on windows in
         # actions/setup-python:
-        os: [linux, windows]
+        os: [linux, windows, macos]
         arch: [x86_64]
         python: ['2.7', '3.5', '3.6', '3.7', '3.8']
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,8 +124,6 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64]
-    env:
-      MACOSX_DEPLOYMENT_TARGET: "10.9"
     steps:
       - uses: actions/checkout@v2
 
@@ -155,30 +153,17 @@ jobs:
           cd ../MAD-X
           ../cpymad/.github/build/macos/madx.sh
 
-      - name: Setup python 2.7
-        uses: actions/setup-python@v2
-        with: {python-version: '2.7'}
-      - run: .github/build/macos/cpymad.sh
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          architecture: ${{ matrix.arch == 'i686' && 'x86' || 'x64' }}
+          python-version: '3.8'
+          # must be explicitly specified if architecture is not x64:
+          miniconda-version: latest
 
-      - name: Setup python 3.5
-        uses: actions/setup-python@v2
-        with: {python-version: '3.5'}
-      - run: .github/build/macos/cpymad.sh
-
-      - name: Setup python 3.6
-        uses: actions/setup-python@v2
-        with: {python-version: '3.6'}
-      - run: .github/build/macos/cpymad.sh
-
-      - name: Setup python 3.7
-        uses: actions/setup-python@v2
-        with: {python-version: '3.7'}
-      - run: .github/build/macos/cpymad.sh
-
-      - name: Setup python 3.8
-        uses: actions/setup-python@v2
-        with: {python-version: '3.8'}
-      - run: .github/build/macos/cpymad.sh
+      - name: Build cpymad wheels
+        # We need 'bash -l' to make conda available within the script:
+        run: bash -l .github/build/macos/cpymad.sh ${{ matrix.arch }} ../MAD-X/dist
 
       - name: Fixup wheel dependencies
         run: |


### PR DESCRIPTION
This adds github actions for macos.

Since I'm not familiar very familiar with the platform, some input would be great. @piotrskowronski Can you check if [these wheels](https://github.com/hibtc/cpymad/suites/1293484409/artifacts/20200418) work for you? After extracting, type:

```
pip install cpymad -f FOLDER
python -c 'import cpymad.libmadx as l; l.start()'
```

The wheels are named after OS version on which they were built (macos 10.14). Do you happen to know, how older versions 10.X will deal with these wheels, i.e. will they accept to install them and work?

Also, the wheels are currently linked against the Accelerate framework for BLAS/LAPACK. Do you know whether this can be expected to be available on user PCs, or should it use MAD-X's builtin substitute implementation?

Resolves #69