### PR TITLE
Drop support for python2 and 32bit

### DIFF
--- a/.github/build/macos/cpymad.sh
+++ b/.github/build/macos/cpymad.sh
@@ -23,7 +23,6 @@ _() {
     { set -x; return $exitcode; } 2>/dev/null
 }
 
-build 2.7
 build 3.5
 build 3.6
 build 3.7

--- a/.github/build/manylinux1/cpymad.sh
+++ b/.github/build/manylinux1/cpymad.sh
@@ -28,7 +28,7 @@ $PY/pip install cython
 $PY/python setup.py sdist
 $PY/pip uninstall cython -y
 
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp3*/bin; do
     "${PYBIN}/pip" install -U setuptools
     "${PYBIN}/pip" wheel dist/*.tar.gz --no-deps -w dist/
 done

--- a/.github/build/msys2/cpymad.sh
+++ b/.github/build/msys2/cpymad.sh
@@ -7,16 +7,9 @@ set -ex
 
 main()
 {
-    ARCH=$1
-    MADXDIR=${2:-$MADXDIR}
-
-    if [[ $ARCH == i686 ]]; then
-        CFLAGS=
-        PLATFORM=win32
-    else
-        CFLAGS=-DMS_WIN64
-        PLATFORM=win-amd64
-    fi
+    MADXDIR=${1:-$MADXDIR}
+    CFLAGS=-DMS_WIN64
+    PLATFORM=win-amd64
 
     build 3.5
     build 3.6

--- a/.github/build/msys2/cpymad.sh
+++ b/.github/build/msys2/cpymad.sh
@@ -11,7 +11,6 @@ main()
     MADXDIR=${2:-$MADXDIR}
 
     # Create python environments:
-    _ conda create -qyf -n py27 python=2.7 wheel cython -c anaconda
     _ conda create -qyf -n py35 python=3.5 wheel cython -c anaconda
     _ conda create -qyf -n py36 python=3.6 wheel cython -c anaconda
     _ conda create -qyf -n py37 python=3.7 wheel cython -c anaconda
@@ -21,7 +20,6 @@ main()
     # Build cpymad wheels:
     if [[ $ARCH == i686 ]]; then
         CFLAGS=
-        build py27 27 win32-2.7 ''
         build py35 35 win32-3.5 .cp35-win32
         build py36 36 win32-3.6 .cp36-win32
         build py37 37 win32-3.7 .cp37-win32
@@ -29,7 +27,6 @@ main()
         build py39 39 win32-3.9 .cp39-win32
     else
         CFLAGS=-DMS_WIN64
-        build py27 27 win-amd64-2.7 ''
         build py35 35 win-amd64-3.5 .cp35-win_amd64
         build py36 36 win-amd64-3.6 .cp36-win_amd64
         build py37 37 win-amd64-3.7 .cp37-win_amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,9 +187,8 @@ jobs:
         # actions/setup-python:
         os: [linux, windows, macos]
         arch: [x86_64]
-        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+        python: ['3.5', '3.6', '3.7', '3.8', '3.9']
         include:
-          - {os: windows, arch: i686, python: '2.7'}
           - {os: windows, arch: i686, python: '3.5'}
           - {os: windows, arch: i686, python: '3.6'}
           - {os: windows, arch: i686, python: '3.7'}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ jobs:
   build_linux:
     name: "Build: Linux"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [i686, x86_64]
     steps:
       - uses: actions/checkout@v2
       - run: echo "MADX_VERSION=$(cat MADX_VERSION)" >> $GITHUB_ENV
@@ -23,7 +20,7 @@ jobs:
           path: ../MAD-X/dist
           key: "\
             madx-${{ env.MADX_VERSION }}-\
-            linux-${{ matrix.arch }}-\
+            linux-\
             patches-${{ hashFiles('.github/patch/*') }}-\
             scripts-${{ hashFiles('.github/build/manylinux1/madx*') }}\
           "
@@ -40,7 +37,7 @@ jobs:
           docker run --rm --init \
             -w /mnt/MAD-X \
             -v `pwd`/..:/mnt \
-            quay.io/pypa/manylinux1_${{ matrix.arch }} \
+            quay.io/pypa/manylinux1_x86_64 \
             ../cpymad/.github/build/manylinux1/madx.sh
 
       - name: Build cpymad wheels
@@ -48,21 +45,18 @@ jobs:
           docker run --rm --init \
             -w /mnt/cpymad \
             -v `pwd`/..:/mnt \
-            quay.io/pypa/manylinux1_${{ matrix.arch }} \
+            quay.io/pypa/manylinux1_x86_64 \
             .github/build/manylinux1/cpymad.sh
 
       - name: Upload cpymad wheels
         uses: actions/upload-artifact@v2
         with:
-          name: dist-linux-${{ matrix.arch }}
+          name: dist-linux
           path: dist
 
   build_windows:
     name: "Build: Windows"
     runs-on: windows-latest
-    strategy:
-      matrix:
-        arch: [i686, x86_64]
     defaults:
       run:
         shell: bash -l {0}
@@ -79,7 +73,7 @@ jobs:
           path: ../MAD-X/dist
           key: "\
             madx-${{ env.MADX_VERSION }}-\
-            windows-${{ matrix.arch }}-\
+            windows-\
             patches-${{ hashFiles('.github/patch/*') }}-\
             scripts-${{ hashFiles('.github/build/manylinux1/madx*') }}\
           "
@@ -93,10 +87,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          architecture: ${{ matrix.arch == 'i686' && 'x86' || 'x64' }}
           python-version: '3.8'
-          # must be explicitly specified if architecture is not x64:
-          miniconda-version: latest
 
       - name: Install build tools
         run: |
@@ -109,20 +100,17 @@ jobs:
 
       - name: Build cpymad wheels
         # We need 'bash -l' to make conda available within the script:
-        run: bash -l .github/build/msys2/cpymad.sh ${{ matrix.arch }} ../MAD-X/dist
+        run: bash -l .github/build/msys2/cpymad.sh ../MAD-X/dist
 
       - name: Upload cpymad wheels
         uses: actions/upload-artifact@v2
         with:
-          name: dist-windows-${{ matrix.arch }}
+          name: dist-windows
           path: dist
 
   build_macos:
     name: "Build: MacOS"
     runs-on: macos-latest
-    strategy:
-      matrix:
-        arch: [x86_64]
     steps:
       - uses: actions/checkout@v2
       - run: echo "MADX_VERSION=$(cat MADX_VERSION)" >> $GITHUB_ENV
@@ -136,7 +124,7 @@ jobs:
           path: ../MAD-X/dist
           key: "\
             madx-${{ env.MADX_VERSION }}-\
-            macos-${{ matrix.arch }}-\
+            macos-\
             patches-${{ hashFiles('.github/patch/*') }}-\
             scripts-${{ hashFiles('.github/build/macos/madx*') }}\
           "
@@ -156,14 +144,11 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          architecture: ${{ matrix.arch == 'i686' && 'x86' || 'x64' }}
           python-version: '3.8'
-          # must be explicitly specified if architecture is not x64:
-          miniconda-version: latest
 
       - name: Build cpymad wheels
         # We need 'bash -l' to make conda available within the script:
-        run: bash -l .github/build/macos/cpymad.sh ${{ matrix.arch }} ../MAD-X/dist
+        run: bash -l .github/build/macos/cpymad.sh ../MAD-X/dist
 
       - name: Fixup wheel dependencies
         run: |
@@ -174,7 +159,7 @@ jobs:
       - name: Upload cpymad wheels
         uses: actions/upload-artifact@v2
         with:
-          name: dist-macos-${{ matrix.arch }}
+          name: dist-macos
           path: dist
 
   test:
@@ -186,14 +171,7 @@ jobs:
         # 32bit python is currently only available on windows in
         # actions/setup-python:
         os: [linux, windows, macos]
-        arch: [x86_64]
         python: ['3.5', '3.6', '3.7', '3.8', '3.9']
-        include:
-          - {os: windows, arch: i686, python: '3.5'}
-          - {os: windows, arch: i686, python: '3.6'}
-          - {os: windows, arch: i686, python: '3.7'}
-          - {os: windows, arch: i686, python: '3.8'}
-          - {os: windows, arch: i686, python: '3.9'}
 
     defaults:
       run:
@@ -204,12 +182,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.arch == 'i686' && 'x86' || 'x64' }}
 
       - name: Download cpymad wheels
         uses: actions/download-artifact@v2
         with:
-          name: dist-${{ matrix.os }}-${{ matrix.arch }}
+          name: dist-${{ matrix.os }}
           path: dist
 
       - name: Install cpymad from wheel
@@ -244,11 +221,10 @@ jobs:
           ref: gh-pages
       - uses: actions/setup-python@v2
         with:
-          architecture: 'x64'
           python-version: '3.x'
       - uses: actions/download-artifact@v2
         with:
-          name: dist-linux-x86_64
+          name: dist-linux
           path: dist
 
       - run: pip install cpymad[doc] -f dist
@@ -285,7 +261,7 @@ jobs:
       - name: Merge artifacts to single folder
         run: |
           mv dist/dist-*/*.whl dist/
-          mv dist/dist-linux-x86_64/*.tar.gz dist/
+          mv dist/dist-linux/*.tar.gz dist/
 
       - name: Install twine
         run: pip install twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers      =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering :: Physics
 long_description_content_type = text/x-rst
@@ -25,7 +24,7 @@ long_description_content_type = text/x-rst
 [options]
 zip_safe = false
 include_package_data = true
-python_requires = >=2.7
+python_requires = >=3.5
 install_requires =
     importlib_resources
     numpy

--- a/src/cpymad/__init__.py
+++ b/src/cpymad/__init__.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 from __future__ import unicode_literals
 
 __title__ = 'cpymad'

--- a/src/cpymad/madx.py
+++ b/src/cpymad/madx.py
@@ -12,7 +12,6 @@ from itertools import product
 from numbers import Number
 import collections.abc as abc
 import os
-import platform
 import subprocess
 import sys
 import warnings
@@ -30,13 +29,6 @@ if sys.version_info < (3, 6):
         "If you need continued support for an older version, let us know at:\n"
         "  https://github.com/hibtc/cpymad/issues")
     warnings.warn(_unsupported_version, DeprecationWarning)
-
-if platform.architecture()[0] == '32bit':
-    _unsupported_platform = (
-        "32bit support will be removed in a future release!\n"
-        "If you need continued support for 32bit builds, let us know at:\n"
-        "  https://github.com/hibtc/cpymad/issues")
-    warnings.warn(_unsupported_platform, DeprecationWarning)
 
 
 __all__ = [

--- a/src/cpymad/stream.py
+++ b/src/cpymad/stream.py
@@ -19,10 +19,7 @@ try:                        # Linux
 except ImportError:         # Windows
     import msvcrt
     from ctypes import windll, byref, WinError
-    try:
-        from ctypes.wintypes import HANDLE, DWORD, LPDWORD, BOOL
-    except ImportError:     # py27
-        from ctypes.wintypes import HANDLE, DWORD, LPVOID as LPDWORD, BOOL
+    from ctypes.wintypes import HANDLE, DWORD, LPDWORD, BOOL
 
     PIPE_NOWAIT = DWORD(0x00000001)
 

--- a/test/test_madx.py
+++ b/test/test_madx.py
@@ -18,25 +18,7 @@ def normalize(path):
     return os.path.normcase(os.path.normpath(path))
 
 
-class _TestCaseCompat(object):
-
-    """
-    Compatibility layer for unittest.TestCase
-    """
-
-    try:
-        assertItemsEqual = unittest.TestCase.assertCountEqual
-    except AttributeError:
-        def assertItemsEqual(self, first, second):
-            """Method missing in python2.6 and renamed in python3."""
-            self.assertEqual(sorted(first), sorted(second))
-
-    def assertLess(self, first, second):
-        """Method missing in python2.6."""
-        self.assertTrue(first < second)
-
-
-class TestMadx(unittest.TestCase, _TestCaseCompat):
+class TestMadx(unittest.TestCase):
 
     """
     Test methods for the Madx class.
@@ -338,7 +320,7 @@ class TestMadx(unittest.TestCase, _TestCaseCompat):
         s1 = self.mad.sequence['s1']
         self.assertEqual(s1.name, 's1')
         seqs = self.mad.sequence
-        self.assertItemsEqual(seqs, ['s1', 's2'])
+        self.assertCountEqual(seqs, ['s1', 's2'])
 
     def test_eval(self):
         self.assertEqual(self.mad.eval(True), True)


### PR DESCRIPTION
Hi,

this PR removes support for 32bit builds and old python < 3.5.

Apart from minor simplifications due to removal of compatibility code (see changes), this will make it easier to maintain the build process in the future. For example migrating to the new UCRT toolchain on windows/msys2 (see #81) is currently only available for 64bit, but will fix long-standing issues with inappropriately linked runtime libraries that users may have to install manually as a result (see e.g. #46).

What do you think @tpersson @rdemaria, @ydutheil, @aoeftiger, @sterbini, or anyone else , do you know anybody who is still using python 3.4 / 32bit, or should we move forward with this? (You can give me thumbs up/down for moving forward)