### PR TITLE
rWIP: emoving seemly useless lines in table definition

### DIFF
--- a/src/cpymad/clibmadx.pxd
+++ b/src/cpymad/clibmadx.pxd
@@ -61,8 +61,6 @@ cdef extern from "madX/mad_table.h" nogil:
         char*** s_cols
         double** d_cols
         name_list* columns
-        double chkick
-        double cvkick
 
     struct table_list:
         int curr


### PR DESCRIPTION
It does not look necessary since `struct table` does not have these attributes in MAD-X.
Let's see if there are side effects...