### PR TITLE
fixes platform identification in setup.py to work correctly with M1/M2 Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ except ImportError:
 # Linux:    linux-x86_64/...
 # Mac:      darwin*
 IS_WIN = get_platform().startswith('win')
-IS_ARM = get_platform().startswith('linux-aarch')
+IS_ARM = get_platform().startswith('linux-aarch') or get_platform().endswith('arm64')
 
 
 # We parse command line options using our own mechanim. We could use

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,13 @@ except ImportError:
     def cythonize(extensions):
         return extensions
 
-# Windows:  win32/win-amd64
-# Linux:    linux-x86_64/...
-# Mac:      darwin*
-IS_WIN = get_platform().startswith('win')
-IS_ARM = get_platform().startswith('linux-aarch') or get_platform().endswith('arm64')
+# Windows:              win32/win-amd64
+# Linux:                linux-x86_64/...
+# Mac Intel:            darwin*
+# Mac Apple Silicon:    *-arm64
+platform = get_platform()
+IS_WIN = platform.startswith('win')
+IS_ARM = platform.startswith('linux-aarch') or platform.endswith('arm64')
 
 
 # We parse command line options using our own mechanim. We could use


### PR DESCRIPTION
line 42 in `setup.py` was:

```py
IS_ARM = get_platform().startswith('linux-aarch')
```
which only returns true for linux arm64 machines. After testing on a MacBook Air M2, setting `IS_ARM = True` enabled successful install. This commit enables the `IS_ARM` flag to function with Apple Silicon architecture Macs (M1/M2/)