### PR TITLE
implement show method [WIP]

### DIFF
--- a/src/cpymad/madx.py
+++ b/src/cpymad/madx.py
@@ -1248,18 +1248,20 @@ class Table(_Mapping):
         """Beam matrix."""
         return self.getmat('sig', idx, dim, dim)
 
-    def pattern(self, regexp):
+    def pattern(self, regexp, column='name'):
         """Return a mask for row names matching the given regular expression."""
         regexp = re.compile(regexp)
-        idx = np.array([regexp.match(nn) for nn in self.name],dtype=bool)
+        idx = np.array([regexp.match(nn) for nn in self[column]],dtype=bool)
         return idx
 
     def crange(self,a,b,column='name'):
         """Return a mask for rows with column between a and b."""
         if column == 'name':
+            r1=re.compile(a)
+            r2=re.compile(b)
             idx = np.zeros(len(self.name),dtype=bool)
-            ia = np.where(np.name==a)[0][0]
-            ib = np.where(np.name==b)[0][0]
+            ia = np.where([r1.match(nn) for nn in self.name])[0][0]
+            ib = np.where([r2.match(nn) for nn in self.name])[0][0]
             idx[ia:ib+1] = True
         else:
             idx = np.array([a <= nn <= b for nn in self.eval(column)],dtype=bool)
@@ -1285,6 +1287,8 @@ class Table(_Mapping):
                 idx = np.where([regex.match(nn) for nn in self.name])[0]
             else:
                 raise(f"Table does not have 'name' column to search")
+        elif isinstance(rows, tuple):
+            idx=np.where(self.crange(rows[0],rows[1]))[0]
         else:
             rows = np.array(rows)
             if rows.dtype.kind == 'b':
@@ -1347,7 +1351,7 @@ class Table(_Mapping):
         else:
             output = pathlib.Path(output)
             with open(output, "w") as fh:
-                fh.write(output)
+                fh.write(result)
 
 
     def eval(self, expr):

--- a/src/cpymad/util.py
+++ b/src/cpymad/util.py
@@ -533,3 +533,12 @@ class ChangeDirectory:
 def remove_count_suffix_from_name(name):
     """Return the :N suffix from an element name."""
     return name.rsplit(':', 1)[0]
+
+
+def _to_str(arr, digits):
+    """covert array to string repr"""
+    if arr.dtype.kind in 'SU':
+        return arr
+    else:
+        fmt = '%%.%dg' % digits
+        return np.array([fmt % nn for nn in arr])


### PR DESCRIPTION
This implements the following methods on table to allow quick inspections:
- `show`: return a pretty-printed version of the table with several options
- `pattern`: return a bool array for row name matching a regexp
- `crange`:  return a bool array for row with column in between two values or two names
- `eval`: compute a new array given an expression

Please let me know if you have comments. If ok, I will add tests and update manual...

Examples assuming tw is a twiss table
```python
$ tw.show('mb','dx/sqrt(betx) dy/sqrt(bety)')
name                  dx/sqrt(betx) dy/sqrt(bety)
mbas2.1r1:1              0.00607198    0.00295083
mbxw.a4r1:1               -0.003267   -0.00443431
mbxw.b4r1:1             -0.00354092   -0.00484049
mbxw.c4r1:1             -0.00389078   -0.00523874
mbxw.d4r1:1             -0.00432186    -0.0056271
mbxw.e4r1:1             -0.00483952   -0.00600381
```

```python
tw.show(tw.pattern('mb')&tw.crange(165,180,'betx')&tw.crange('ip3','ip4'),'betx')
name                     betx
mb.c13r3.b1:1         165.983
mb.c17r3.b1:1         165.184
mb.c21r3.b1:1         165.172
mb.c23r3.b1:1         165.012
mb.c25r3.b1:1         165.012
mb.c27r3.b1:1         165.012
mb.c29r3.b1:1         165.012
mb.c31r3.b1:1         165.012
mb.c33r3.b1:1         165.012
mb.a34l4.b1:1         165.012
mb.a32l4.b1:1         165.012
mb.a30l4.b1:1         165.012
mb.a28l4.b1:1         165.012
mb.a26l4.b1:1         165.012
mb.a24l4.b1:1         165.012
mb.a22l4.b1:1         165.012
mb.a18l4.b1:1         165.024
mb.a14l4.b1:1         165.036
```
   