### PR TITLE
Add property to access current beam

### DIFF
--- a/src/cpymad/clibmadx.pxd
+++ b/src/cpymad/clibmadx.pxd
@@ -226,6 +226,7 @@ cdef enum:
 # Global variables:
 cdef extern from "madX/mad_gvar.h" nogil:
     command* options            # current options
+    command* current_beam       # default beam
     sequence* current_sequ      # active sequence
     table_list* table_register  # list of all tables
     char_p_array* tmp_p_array   # temporary buffer for splits

--- a/src/cpymad/libmadx.pyx
+++ b/src/cpymad/libmadx.pyx
@@ -59,6 +59,9 @@ __all__ = [
 
     'get_options',
 
+    # beam
+    'get_current_beam',
+
     # iterate sequences
     'sequence_exists',
     'get_sequence_names',
@@ -252,6 +255,13 @@ def get_globals() -> list:
     Get a list of names of all global variables.
     """
     return _name_list(clib.variable_list.list)
+
+
+def get_current_beam() -> dict:
+    """
+    Get properties of current default beam.
+    """
+    return _parse_command(clib.current_beam)
 
 
 def sequence_exists(sequence_name: str) -> bool:

--- a/src/cpymad/madx.py
+++ b/src/cpymad/madx.py
@@ -276,6 +276,11 @@ class Madx:
         """Values of current options."""
         return Command(self, self._libmadx.get_options())
 
+    @property
+    def beam(self):
+        """Get the current default beam."""
+        return Command(self._madx, self._libmadx.get_current_beam())
+
     # Methods:
 
     def input(self, text: str) -> bool:

--- a/test/test_madx.py
+++ b/test/test_madx.py
@@ -341,6 +341,17 @@ def test_verbose(mad):
     assert mad.options.info is True
 
 
+def test_current_beam(mad):
+    mad.beam(particle='electron', ex=1, ey=2)
+    assert mad.beam.particle == 'electron'
+    assert mad.beam.ex == 1
+    assert mad.beam.ey == 2
+    mad.beam(particle='positron', ex=2, ey=1)
+    assert mad.beam.particle == 'positron'
+    assert mad.beam.ex == 2
+    assert mad.beam.ey == 1
+
+
 def test_active_sequence(mad):
     mad.input(SEQU)
     mad.command.beam('ex=1, ey=2, particle=electron, sequence=s1;')


### PR DESCRIPTION
Resolves #122

@rdemaria This will change the property `madx.beam` to return the current beam (instead of deferring to `madx.command.beam` as was done until now), e.g.:

```python
mad = Madx()
mad.beam(particle='electron')
assert mad.beam.particle == 'electron'
```